### PR TITLE
add support for SphericalGeography values

### DIFF
--- a/trino/trino.go
+++ b/trino/trino.go
@@ -1468,7 +1468,7 @@ func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
 			return nil, err
 		}
 		return vv.Bool, err
-	case "json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "unknown":
+	case "json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "uuid", "SphericalGeography", "unknown":
 		vv, err := scanNullString(v)
 		if !vv.Valid {
 			return nil, err

--- a/trino/trino_test.go
+++ b/trino/trino_test.go
@@ -1419,6 +1419,12 @@ func TestTypeConversion(t *testing.T) {
 				[]interface{}{"b"},
 			},
 		},
+		{
+			DataType:                   "SphericalGeography",
+			RawType:                    "SphericalGeography",
+			ResponseUnmarshalledSample: "Point (0 0)",
+			ExpectedGoValue:            "Point (0 0)",
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
As mentioned in https://github.com/sigmacomputing/trino-go-client/pull/7#issuecomment-2073217424, the query result for a value with the `SphericalGeography` type seems to be a WKT string, so this change handles that case.